### PR TITLE
Fix units causing conversion issues

### DIFF
--- a/docs/assets/csv/metric/asia/china.csv
+++ b/docs/assets/csv/metric/asia/china.csv
@@ -1,69 +1,69 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 China,Beijing,Chaoyang,Beijing Emperor Center & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.19 m,11.76 m,Yes
-China,Beijing,Chaoyang,Beijing Fangyuanli ID Mall Bona & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.92m,10.9 m,Unk
-China,Beijing,Fangshan,Beijing Fangshan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85m,11.76 m,Unk
-China,Beijing,Haidian,Beijing Qinghe CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,16.48m,8.31 m,Unk
-China,Beijing,Shijingshan,Beijing Shijingshan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.22m,12.68m,Unk
-China,Fujian,Fuzhou,Fuzhou Strait Culture Art Center Jinyi & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.39m,10.59 m,Unk
-China,Fujian,Xiamen,Xiamen Huli Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.18m,10.40m,Unk
-China,Guangdong,Guangzhou,Guangzhou New Park Mei Ah & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.55m,12.31 m,Unk
-China,Guangdong,Shenzhen,Shenzhen One Avenue CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85m,11.76 m,Unk
-China,Guangdong,Shenzhen,Shenzhen Maxland Jinyi & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.74m,11.80 m,Unk
-China,Guangdong,Shenzhen,Shenzhen PAFC Mall Emperor & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.80m,11.00 m,Unk
-China,Guangxi,Nanning,Nanning Qingxiu Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.76m,11.67 m,Unk
-China,Guizhou,Guiyang,Guiyang The Future Ark Cross & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,32.16m,18.17 m,Unk
-China,Guizhou,Guiyang,Guiyang Incity CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.96m,11.94 m,Unk
-China,Guizhou,Guiyang,Guiyang Zhongda Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.92m,9.91 m,Unk
-China,Hebei,Shijiazhuang,Shijiazhuang MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.07m,13.90 m,Unk
-China,Heilongjiang,Harbin,Haxi Wanda Plaza IMAX,1.90:1,IMAX Cola,1.90:1,No,20.54m,11.49 m,Unk
-China,Henan,Zhengzhou,Zhengzhou Yoyo Park CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.60m,10.64 m,Unk
-China,Henan,Zhengzhou,Zhengzhou Wanda Erqi & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.30m,11.70 m,Unk
-China,Hubei,Wuhan,Wuhan Wushang Moore & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.34m,11.10 m,Unk
-China,Hunan,Changsha,Changsha Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.42m,11.51 m,Unk
+China,Beijing,Chaoyang,Beijing Fangyuanli ID Mall Bona & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.92 m,10.9 m,Unk
+China,Beijing,Fangshan,Beijing Fangshan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85 m,11.76 m,Unk
+China,Beijing,Haidian,Beijing Qinghe CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,16.48 m,8.31 m,Unk
+China,Beijing,Shijingshan,Beijing Shijingshan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.22 m,12.68 m,Unk
+China,Fujian,Fuzhou,Fuzhou Strait Culture Art Center Jinyi & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.39 m,10.59 m,Unk
+China,Fujian,Xiamen,Xiamen Huli Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.18 m,10.40 m,Unk
+China,Guangdong,Guangzhou,Guangzhou New Park Mei Ah & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.55 m,12.31 m,Unk
+China,Guangdong,Shenzhen,Shenzhen One Avenue CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85 m,11.76 m,Unk
+China,Guangdong,Shenzhen,Shenzhen Maxland Jinyi & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.74 m,11.80 m,Unk
+China,Guangdong,Shenzhen,Shenzhen PAFC Mall Emperor & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.80 m,11.00 m,Unk
+China,Guangxi,Nanning,Nanning Qingxiu Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.76 m,11.67 m,Unk
+China,Guizhou,Guiyang,Guiyang The Future Ark Cross & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,32.16 m,18.17 m,Unk
+China,Guizhou,Guiyang,Guiyang Incity CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.96 m,11.94 m,Unk
+China,Guizhou,Guiyang,Guiyang Zhongda Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.92 m,9.91 m,Unk
+China,Hebei,Shijiazhuang,Shijiazhuang MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.07 m,13.90 m,Unk
+China,Heilongjiang,Harbin,Haxi Wanda Plaza IMAX,1.90:1,IMAX Cola,1.90:1,No,20.54 m,11.49 m,Unk
+China,Henan,Zhengzhou,Zhengzhou Yoyo Park CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.60 m,10.64 m,Unk
+China,Henan,Zhengzhou,Zhengzhou Wanda Erqi & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.30 m,11.70 m,Unk
+China,Hubei,Wuhan,Wuhan Wushang Moore & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.34 m,11.10 m,Unk
+China,Hunan,Changsha,Changsha Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.42 m,11.51 m,Unk
 China,Jiangsu,Jingjiang City,Jingjiang In City CGV & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Unk
-China,Jiangsu,Nanjing,Nanjing Unimall Omnijoi & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.92m,11.45 m,Unk
-China,Jiangsu,Suzhou,Kunshan MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.84m,12.30 m,Unk
-China,Jiangsu,Wuxi,Wuxi Livat Jinyi & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.22m,12.68 m,Unk
-China,Jiangsu,Wuxi,Wuxi Big World & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.82m,10.83 m,Unk
-China,Jiangsu,Wuxi,Wuxi Yaohan CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.34m,10.73 m,Unk
-China,Jiangsu,Wuxi,Wuxi Jiangnan Joy City Big World & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.00m,13.00m,Unk
-China,Jiangxi,Nanchang,Nanchang MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.98m,9.44m,Unk
-China,Liaoning,Dalian,Dalian Jingkai Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.01m,11.51m,Unk
-China,Liaoning,Shenyang,Shenyang Olympic Wanda IMAX,1.90:1,IMAX Cola,1.90:1,No,22.19m,11.61m,Unk
-China,Inner Mongolia,Hohhot,Hohhot East Xinhua Road Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.24m,10.87m,Unk
-China,Shandong,Jinan,Jinan Gaoxin Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.02m,11.85m,Unk
-China,Shandong,Jinan,Jinan MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85m,11.73m,Unk
-China,Shandong,Qingdao,Qingdao Wanda CBD Cinema IMAX,1.90:1,IMAX Cola,1.90:1,No,21.20m,11.00m,Unk
-China,Shanghai,Baoshan,Wanda Shanghai Baoshan & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.05m,10.48m,Unk
-China,Shanghai,Hongkou,Jinyi Cinema & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.82m,8.44m,Unk
-China,Shanghai,Huangpu,Shanghai One East Palace & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.49m,10.11m,Unk
-China,Shanghai,Jing'an,Shanghai Daning IMIX Park Hoyts & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.88m,13.46m,Unk
-China,Shanghai,Jinshan,Shanghai Jinshan Wanda & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,23.16m,12.10m,Unk
-China,Shanxi,Taiyuan,Taiyuan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,26.51m,14.06m,Unk
-China,Shanxi,Taiyuan,Taiyuan MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85m,11.86m,Unk
-China,Sichuan,Chengdu,Chengdu MixC Ph2 Broadway & IMAX,1.90:1,IMAX Cola,1.90:1,No,24.52m,12.80m,Unk
-China,Sichuan,Chengdu,Chengdu Shin Kong Plaza Emperor & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.87m,12.46m,Unk
-China,Yunnan,Kunming,Kunming Xishan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.13m,11.66m,Unk
-China,Zhejiang,Ningbo,Ningbo MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.88m,13.92m,Unk
-China,Beijing,Chaoyang,China National Film Museum & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,30.17m,19.51m,Unk
+China,Jiangsu,Nanjing,Nanjing Unimall Omnijoi & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.92 m,11.45 m,Unk
+China,Jiangsu,Suzhou,Kunshan MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.84 m,12.30 m,Unk
+China,Jiangsu,Wuxi,Wuxi Livat Jinyi & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.22 m,12.68 m,Unk
+China,Jiangsu,Wuxi,Wuxi Big World & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.82 m,10.83 m,Unk
+China,Jiangsu,Wuxi,Wuxi Yaohan CGV & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.34 m,10.73 m,Unk
+China,Jiangsu,Wuxi,Wuxi Jiangnan Joy City Big World & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.00 m,13.00 m,Unk
+China,Jiangxi,Nanchang,Nanchang MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.98 m,9.44 m,Unk
+China,Liaoning,Dalian,Dalian Jingkai Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.01 m,11.51 m,Unk
+China,Liaoning,Shenyang,Shenyang Olympic Wanda IMAX,1.90:1,IMAX Cola,1.90:1,No,22.19 m,11.61 m,Unk
+China,Inner Mongolia,Hohhot,Hohhot East Xinhua Road Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.24 m,10.87 m,Unk
+China,Shandong,Jinan,Jinan Gaoxin Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.02 m,11.85 m,Unk
+China,Shandong,Jinan,Jinan MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85 m,11.73 m,Unk
+China,Shandong,Qingdao,Qingdao Wanda CBD Cinema IMAX,1.90:1,IMAX Cola,1.90:1,No,21.20 m,11.00 m,Unk
+China,Shanghai,Baoshan,Wanda Shanghai Baoshan & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.05 m,10.48 m,Unk
+China,Shanghai,Hongkou,Jinyi Cinema & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.82 m,8.44 m,Unk
+China,Shanghai,Huangpu,Shanghai One East Palace & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.49 m,10.11 m,Unk
+China,Shanghai,Jing'an,Shanghai Daning IMIX Park Hoyts & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.88 m,13.46 m,Unk
+China,Shanghai,Jinshan,Shanghai Jinshan Wanda & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,23.16 m,12.10 m,Unk
+China,Shanxi,Taiyuan,Taiyuan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,26.51 m,14.06 m,Unk
+China,Shanxi,Taiyuan,Taiyuan MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.85 m,11.86 m,Unk
+China,Sichuan,Chengdu,Chengdu MixC Ph2 Broadway & IMAX,1.90:1,IMAX Cola,1.90:1,No,24.52 m,12.80 m,Unk
+China,Sichuan,Chengdu,Chengdu Shin Kong Plaza Emperor & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.87 m,12.46 m,Unk
+China,Yunnan,Kunming,Kunming Xishan Wanda & IMAX,1.90:1,IMAX Cola,1.90:1,No,22.13 m,11.66 m,Unk
+China,Zhejiang,Ningbo,Ningbo MixC & IMAX,1.90:1,IMAX Cola,1.90:1,No,25.88 m,13.92 m,Unk
+China,Beijing,Chaoyang,China National Film Museum & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,30.17 m,19.51 m,Unk
 China,Beijing,Tongzhou,Universal Beijing Resort Universal City Walk & IMAX,N/A,IMAX Cola,1.90:1,No,0 m,0 m,Unk
-China,Guangdong,Dongguan,Dongguan Wanda & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,32.06m,19.51m,Unk
+China,Guangdong,Dongguan,Dongguan Wanda & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,32.06 m,19.51 m,Unk
 China,Guangdong,Guangzhou,Guangzhou Rock Square Flying & IMAX,N/A,IMAX Cola,1.90:1,No,0 m,0 m,Unk
 China,Guangdong,Maoming,Maoming Donghui & IMAX,N/A,IMAX Cola,1.90:1,No,0 m,0 m,Unk
 China,Guangdong,Shenzhen,Shenzhen Longgang Tian An MixC & IMAX,N/A,IMAX Cola,1.90:1,No,0 m,0 m,Unk
-China,Heilongjiang,Harbin,Harbin Tai Lai Era & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,28.65m,21.30m,Unk
+China,Heilongjiang,Harbin,Harbin Tai Lai Era & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,28.65 m,21.30 m,Unk
 China,Heilongjiang,Harbin,Harbin MixC & IMAX,N/A,IMAX Cola,1.90:1,No,0 m,0 m,Unk
 China,Hubei,Wuhan,Wuhan Wushang Dream Plaza Moore & IMAX,N/A,IMAX Cola,N/A,No,0 m,0 m,Unk
-China,Liaoning,Shenyang,"IMAX, Liaoning Science & Technology Museum",1.43:1,IMAX GT Laser,1.43:1,No,28.98m,22.00m,Unk
+China,Liaoning,Shenyang,"IMAX, Liaoning Science & Technology Museum",1.43:1,IMAX GT Laser,1.43:1,No,28.98 m,22.00 m,Unk
 China,Shandong,Jinan,Shandong Science & Technology Museum,N/A,IMAX GT Laser,N/A,No,0 m,0 m,Unk
-China,Yunnan,Kunming,Kunming Panxing Dadu LLC & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,23.10m,17.37m,Unk
-China,Beijing,Chaoyang,"IMAX 3D, China Science & Technology Museum",1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,29.58m,21.93m,Unk
-China,Beijing,Chaoyang,"IMAX Dome, China Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,30m,0 m,Unk
-China,Chongqing,Jiangbei,"IMAX, Chongqing Science & Technology Museum",1.43:1,N/A,N/A,IMAX SR 15/70 mm,22.00m,16.00m,Unk
-China,Chongqing,Yuzhong,"IMAX Dome, Chongqing Children's Museum",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,18m,0 m,Unk
-China,Guangdong,Dongguan,"IMAX Dome, Dongguan Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,18m,0 m,Unk
-China,Heilongjiang,Daqing,"IMAX, Da Qing Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,18m,0 m,Unk
+China,Yunnan,Kunming,Kunming Panxing Dadu LLC & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,23.10 m,17.37 m,Unk
+China,Beijing,Chaoyang,"IMAX 3D, China Science & Technology Museum",1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,29.58 m,21.93 m,Unk
+China,Beijing,Chaoyang,"IMAX Dome, China Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,30 m,0 m,Unk
+China,Chongqing,Jiangbei,"IMAX, Chongqing Science & Technology Museum",1.43:1,N/A,N/A,IMAX SR 15/70 mm,22.00 m,16.00 m,Unk
+China,Chongqing,Yuzhong,"IMAX Dome, Chongqing Children's Museum",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,18 m,0 m,Unk
+China,Guangdong,Dongguan,"IMAX Dome, Dongguan Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,18 m,0 m,Unk
+China,Heilongjiang,Daqing,"IMAX, Da Qing Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,18 m,0 m,Unk
 China,Heilongjiang,Harbin,"IMAX, Heilongjiang Science & Technology Center",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,0 m,0 m,Unk
-China,Jiangsu,Nanjing,"IMAX, Nanjing Juvenile Science & Technology Center",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,21m,0 m,Unk
+China,Jiangsu,Nanjing,"IMAX, Nanjing Juvenile Science & Technology Center",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,21 m,0 m,Unk
 China,Shanghai,Pudong,"IMAX Dome, Shanghai Science & Technology Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,23.0 m,0 m,Unk
 China,Shanghai,Pudong,"IMAX 3D, Shanghai Science & Technology Museum",1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,24.3 m, 18.3 m,Unk

--- a/docs/assets/csv/metric/asia/hongkong.csv
+++ b/docs/assets/csv/metric/asia/hongkong.csv
@@ -1,4 +1,4 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
-Kowloon,Yau Tsim Mong,Hongkong ISQUARE Emperor & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.94m,11.80m,Yes
-Kowloon,Yau Tsim Mong,MCL Cinemas IMAX @ K11 Art House,1.90:1,IMAX Cola,1.90:1,No,20.70m,11.77m,Yes
-Kowloon,Yau Tsim Mong,"OMNIMAX, Hong Kong Space Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,23.00m,0 m,Unk
+Kowloon,Yau Tsim Mong,Hongkong ISQUARE Emperor & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.94 m,11.80 m,Yes
+Kowloon,Yau Tsim Mong,MCL Cinemas IMAX @ K11 Art House,1.90:1,IMAX Cola,1.90:1,No,20.70 m,11.77 m,Yes
+Kowloon,Yau Tsim Mong,"OMNIMAX, Hong Kong Space Museum",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,23.00 m,0 m,Unk

--- a/docs/assets/csv/metric/asia/india.csv
+++ b/docs/assets/csv/metric/asia/india.csv
@@ -2,10 +2,10 @@ Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum A
 Delhi,Delhi,INOX Vishal Mall & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 Delhi,New Delhi,INOX Paras & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 Delhi,New Delhi,PVR Priya & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-Delhi,New Delhi,PVR Select City Walk Gold & IMAX,1.90:1,IMAX Cola,1.90:1,No,16.30m,9.10m,Yes
-Maharashtra,Mumbai,PVR Phoenix IMAX,1.90:1,IMAX Cola,1.90:1,No,18.10m,9.40m,Yes
+Delhi,New Delhi,PVR Select City Walk Gold & IMAX,1.90:1,IMAX Cola,1.90:1,No,16.30 m,9.10 m,Yes
+Maharashtra,Mumbai,PVR Phoenix IMAX,1.90:1,IMAX Cola,1.90:1,No,18.10 m,9.40 m,Yes
 Maharashtra,Mumbai,PVR INOX Jio World Plaza Bkc & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 Maharashtra,Mumbai,EROS & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 Tamil Nadu,Coimbatore,Broadway Megaaplex & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-Uttar Pradesh,Noida,PVR Superplex Mall of India & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,21.50m,12.10m,Yes
-Gujarat,Ahmedabad,"IMAX 3D, Gujarat Science City",1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,29.00m,20.04m,No
+Uttar Pradesh,Noida,PVR Superplex Mall of India & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,21.50 m,12.10 m,Yes
+Gujarat,Ahmedabad,"IMAX 3D, Gujarat Science City",1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,29.00 m,20.04 m,No

--- a/docs/assets/csv/metric/asia/indonesia.csv
+++ b/docs/assets/csv/metric/asia/indonesia.csv
@@ -1,10 +1,10 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Banten,South Tangerang,Bintaro Xchange 2 XXI & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 Banten,Tangerang,Alam Sutera XXI & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-DKI Jakarta,South Jakarta,Gandaria City XXI & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.40m,10.80m,Yes
-DKI Jakarta,North Jakarta,Kelapa Gading XXI & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.60m,14.30m,Yes
+DKI Jakarta,South Jakarta,Gandaria City XXI & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.40 m,10.80 m,Yes
+DKI Jakarta,North Jakarta,Kelapa Gading XXI & IMAX,1.90:1,IMAX Cola,1.90:1,No,23.60 m,14.30 m,Yes
 Central Java,Semarang,The Park Semarang XXI & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 West Java,Bandung,Summarecon Mall Bandung XXI & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 West Java,Cikarang,AEON Mall Deltamas & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 West Java,Depok,Margo City XXI & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-DKI Jakarta,East Jakarta,Keong Emas IMAX,1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,29.30m,21.50m,No
+DKI Jakarta,East Jakarta,Keong Emas IMAX,1.43:1,N/A,N/A,IMAX GT3D 15/70 mm,29.30 m,21.50 m,No

--- a/docs/assets/csv/metric/asia/japan.csv
+++ b/docs/assets/csv/metric/asia/japan.csv
@@ -1,30 +1,30 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Chūbu,Gifu,Aeon Kakamigahara & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Chūbu,Nagoya,109 Cinemas Nagoya & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.10m,8.80m,Yes
+Chūbu,Nagoya,109 Cinemas Nagoya & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.10 m,8.80 m,Yes
 Chūbu,Shizuoka Prefecture,Cinema Sunshine Lalaport Numazu & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Hokkaido,Hokkaido,United Cinemas Sapporo Factory & IMAX,1.90:1,IMAX Cola,1.90:1,No,24.90m,13.90m,Yes
+Hokkaido,Hokkaido,United Cinemas Sapporo Factory & IMAX,1.90:1,IMAX Cola,1.90:1,No,24.90 m,13.90 m,Yes
 Okinawa,Okinawa,United Cinemas Parco City Urasoe & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kansai,Nara Prefecture,IMAX Cinema Sunshine Yamatokoriyama,1.90:1,IMAX Cola,1.90:1,No,18.30m,9.60m,Yes
+Kansai,Nara Prefecture,IMAX Cinema Sunshine Yamatokoriyama,1.90:1,IMAX Cola,1.90:1,No,18.30 m,9.60 m,Yes
 Kansai,Osaka,AEON Shijonawate & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
 Kantō,Chiba,AEON Ichikawa Myoden & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
 Kantō,Chiba,TOHO Nagareyama-Takanomori & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
 Kantō,Chiba,Aeon Makuhari Shin-toshin & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
 Kantō,Chiyodaku,TOHO Cinemas Hibiya & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kantō,Fujisawa City,109 Cinemas Shonan & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.60m,11.50m,Yes
-Kantō,Kawasaki,109 Cinemas Kawasaki & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.40m,9.00m,Yes
-Kantō,Kiba,109 Cinemas Kiba & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.00m,9.10m,Yes
+Kantō,Fujisawa City,109 Cinemas Shonan & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.60 m,11.50 m,Yes
+Kantō,Kawasaki,109 Cinemas Kawasaki & IMAX,1.90:1,IMAX Cola,1.90:1,No,17.40 m,9.00 m,Yes
+Kantō,Kiba,109 Cinemas Kiba & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.00 m,9.10 m,Yes
 Kantō,Matsudo,United Cinemas Matsudo & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kantō,Nerima-ku,United Cinemas Toshimaen & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.00m,9.50m,Yes
-Kantō,Saitama,109 Cinemas Shobu & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.40m,9.80m,Yes
-Kantō,Tokyo,109 Cinemas Futako Tamagawa & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.50m,9.90m,Yes
-Kantō,Tokyo,109 Cinemas Grandberry Mall & IMAX,1.90:1,IMAX Cola,1.90:1,No,16.80m,8.60m,Yes
+Kantō,Nerima-ku,United Cinemas Toshimaen & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.00 m,9.50 m,Yes
+Kantō,Saitama,109 Cinemas Shobu & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.40 m,9.80 m,Yes
+Kantō,Tokyo,109 Cinemas Futako Tamagawa & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.50 m,9.90 m,Yes
+Kantō,Tokyo,109 Cinemas Grandberry Mall & IMAX,1.90:1,IMAX Cola,1.90:1,No,16.80 m,8.60 m,Yes
 Kantō,Tokyo,Aeon Chofu & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kantō,Tokyo,Toho Cinemas Shinjyuku & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.5m,10.9m,Yes
-Kantō,Tsuchiura-shi,Cinema Sunshine Tsuchiura & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,16.7m,9.2m,Yes
-Kantō,Urawa,United Cinemas Urawa & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.2m,9.2m,Yes
+Kantō,Tokyo,Toho Cinemas Shinjyuku & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.5 m,10.9 m,Yes
+Kantō,Tsuchiura-shi,Cinema Sunshine Tsuchiura & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,16.7 m,9.2 m,Yes
+Kantō,Urawa,United Cinemas Urawa & IMAX,1.90:1,IMAX Cola,1.90:1,No,18.2 m,9.2 m,Yes
 Kyushu,Fukuoka,Aeon Fukuoka & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kyushu,Hakata-ku,United Cinemas Canal City 13 & IMAX,1.90:1,IMAX Cola,1.90:1,No,15.10m,8.40m,Yes
+Kyushu,Hakata-ku,United Cinemas Canal City 13 & IMAX,1.90:1,IMAX Cola,1.90:1,No,15.10 m,8.40 m,Yes
 Chūgoku,Okayama,Aeon Okayama & IMAX,,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kansai,Osaka,109 Cinemas Osaka Expocity & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,26.00m,18.00m,Yes
-Kantō,Tokyo,Grand Cinema Sunshine & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,25.8m,18.9m,Yes
-Kyushu,Kagoshima,"Space Theatre, Municipal Science Hall",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,20.50m,0 m,Unk
+Kansai,Osaka,109 Cinemas Osaka Expocity & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,26.00 m,18.00 m,Yes
+Kantō,Tokyo,Grand Cinema Sunshine & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,25.8 m,18.9 m,Yes
+Kyushu,Kagoshima,"Space Theatre, Municipal Science Hall",Dome 1.43:1,N/A,N/A,IMAX GT Dome 15/70 mm,20.50 m,0 m,Unk

--- a/docs/assets/csv/metric/asia/kuwait.csv
+++ b/docs/assets/csv/metric/asia/kuwait.csv
@@ -1,3 +1,3 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
-Ahmadi,Fahaheel,Cinescape Al-Kout & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.00m,11.80m,Yes
-Hawalli,Salmiya,"IMAX, The Scientific Center Kuwait",1.43:1,IMAX GT Laser,1.43:1,No,20.00m,14.80m,No
+Ahmadi,Fahaheel,Cinescape Al-Kout & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.00 m,11.80 m,Yes
+Hawalli,Salmiya,"IMAX, The Scientific Center Kuwait",1.43:1,IMAX GT Laser,1.43:1,No,20.00 m,14.80 m,No

--- a/docs/assets/csv/metric/asia/malaysia.csv
+++ b/docs/assets/csv/metric/asia/malaysia.csv
@@ -1,7 +1,7 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Kuala Lumpur,Kuala Lumpur,"Aurum Theatre, The Exchange TRX & IMAX",1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Kuala Lumpur,Kuala Lumpur,TGV Pavilion Bukit Jalil & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,20.88m,11.08m,Yes
+Kuala Lumpur,Kuala Lumpur,TGV Pavilion Bukit Jalil & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,20.88 m,11.08 m,Yes
 Kuala Lumpur,Kuala Lumpur,TGV Suria KLCC & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-Selangor,Petaling Jaya,TGV 1 Utama & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,22.00m,12.50m,Yes
+Selangor,Petaling Jaya,TGV 1 Utama & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,22.00 m,12.50 m,Yes
 Putrajaya,Putrajaya,GSC IOI City Mall & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-Kuala Lumpur,Kuala Lumpur,TGV Sunway Velocity & IMAX,1.43:1,IMAX Cola,1.90:1,No,25.90m,19.40m,Yes
+Kuala Lumpur,Kuala Lumpur,TGV Sunway Velocity & IMAX,1.43:1,IMAX Cola,1.90:1,No,25.90 m,19.40 m,Yes

--- a/docs/assets/csv/metric/asia/qatar.csv
+++ b/docs/assets/csv/metric/asia/qatar.csv
@@ -1,2 +1,2 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
-Ad-Dawhah,Doha,Novo Mall Of Qatar & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,17.90m,9.90m,Yes
+Ad-Dawhah,Doha,Novo Mall Of Qatar & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,17.90 m,9.90 m,Yes

--- a/docs/assets/csv/metric/asia/saudiarabia.csv
+++ b/docs/assets/csv/metric/asia/saudiarabia.csv
@@ -5,4 +5,4 @@ Mecca Province,Jeddah,VOX Jeddah Town Square & IMAX,1.90:1,IMAX Cola,1.90:1,No,0
 Mecca Province,Jeddah,VOX Red Sea Mall & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
 Riyadh Province,Riyadh,AMC Al Khair 9 & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
 Riyadh Province,Riyadh,Empire Cinemas Rabwa & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Eastern Province,Al Khobar,"Science Dome, Sultan Bin Abdulaziz Science & Technology Center",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,20.00m,0 m,No
+Eastern Province,Al Khobar,"Science Dome, Sultan Bin Abdulaziz Science & Technology Center",Dome 1.43:1,N/A,N/A,IMAX SR Dome 15/70 mm,20.00 m,0 m,No

--- a/docs/assets/csv/metric/asia/singapore.csv
+++ b/docs/assets/csv/metric/asia/singapore.csv
@@ -1,4 +1,4 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Central Region,Geylang,Shaw Paya Lebar Quarter & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Central Region,Orchard,Shaw Theatres Lido & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.00m,9.00m,Yes
+Central Region,Orchard,Shaw Theatres Lido & IMAX,1.90:1,IMAX Cola,1.90:1,No,19.00 m,9.00 m,Yes
 East Region,Changi,Shaw Theatres Jewel & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes

--- a/docs/assets/csv/metric/asia/southkorea.csv
+++ b/docs/assets/csv/metric/asia/southkorea.csv
@@ -1,10 +1,10 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Gyeonggi,Hwaseong,CGV Dongtan & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
 Gyeonggi,Pyeongtaek,CGV Pyeongtaek & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-Gyeonggi,Seoul,CGV Apgujeong & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,16.00m,9.00m,Yes
+Gyeonggi,Seoul,CGV Apgujeong & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,16.00 m,9.00 m,Yes
 Gyeonggi,Seoul,CGV Yeongdeungpo & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Gyeonggi,Suwon,CGV Gwangyo & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.00m,12.00m,Yes
+Gyeonggi,Suwon,CGV Gwangyo & IMAX,1.90:1,IMAX Cola,1.90:1,No,20.00 m,12.00 m,Yes
 Hoseo,Cheonan,CGV Cheonon Pentaport & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,0 m,0 m,Yes
-Hoseo,Daejeon,CGV Daejeon Terminal & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,16.00m,8.50m,Yes
-Yeongnam,Daegu,CGV Daegu Spectrum City & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.30m,12.60m,Yes
-Gyeonggi,Seoul,CGV Yongsan I-Park Mall & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,31.00m,22.40m,Yes
+Hoseo,Daejeon,CGV Daejeon Terminal & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,16.00 m,8.50 m,Yes
+Yeongnam,Daegu,CGV Daegu Spectrum City & IMAX,1.90:1,IMAX Cola,1.90:1,No,21.30 m,12.60 m,Yes
+Gyeonggi,Seoul,CGV Yongsan I-Park Mall & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,31.00 m,22.40 m,Yes

--- a/docs/assets/csv/metric/asia/taiwan.csv
+++ b/docs/assets/csv/metric/asia/taiwan.csv
@@ -1,6 +1,6 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Northern Taiwan,New Taipei,New Taipei Yulon City VieShow & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Northern Taiwan,New Taipei City,Vie Show Cinemas Banqiao Mega City IMAX,1.90:1,IMAX Cola,1.90:1,No,21.30m,11.15m,Yes
+Northern Taiwan,New Taipei City,Vie Show Cinemas Banqiao Mega City IMAX,1.90:1,IMAX Cola,1.90:1,No,21.30 m,11.15 m,Yes
 Southern Taiwan,Jiayi City,IN89 Cinemax Chiayi & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Southern Taiwan,Kaohsiung,Kaohsiung Vie Show IMAX,1.90:1,IMAX Cola,1.90:1,No,15.90m,8.20m,Yes
-Northern Taiwan,Taipei,Miramar IMAX,1.43:1,IMAX GT Laser,1.43:1,No,28.40m,21.20m,Yes
+Southern Taiwan,Kaohsiung,Kaohsiung Vie Show IMAX,1.90:1,IMAX Cola,1.90:1,No,15.90 m,8.20 m,Yes
+Northern Taiwan,Taipei,Miramar IMAX,1.43:1,IMAX GT Laser,1.43:1,No,28.40 m,21.20 m,Yes

--- a/docs/assets/csv/metric/asia/thailand.csv
+++ b/docs/assets/csv/metric/asia/thailand.csv
@@ -1,7 +1,7 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Central Thailand,Bangkok,"IMAX at ICON CINECONIC, ICONSIAM",1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Central Thailand,Bangkok,"IMAX Theatre, Quartier Cine-Art",1.90:1,IMAX Cola,1.90:1,No,25.70m,13.70m,Yes
-Central Thailand,Nonthaburi,Esplanade Cineplex Ngamwongwan-Khaerai & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,22.00m,11.00m,Yes
-Central Thailand,Samutprakarn,IMAX Mega Cineplex at Mega Bangna,1.90:1,IMAX Laser XT,1.90:1,No,19.60m,10.20m,Yes
-Central Thailand,Bangkok,"IMAX, Major Cineplex Ratchayothin",1.43:1,IMAX Cola,1.90:1,No,24.00m,17.00m,Yes
-Central Thailand,Bangkok,"Krungsri IMAX, Paragon Cineplex",1.43:1,IMAX Cola,1.90:1,No,27.30m,19.90m,Yes
+Central Thailand,Bangkok,"IMAX Theatre, Quartier Cine-Art",1.90:1,IMAX Cola,1.90:1,No,25.70 m,13.70 m,Yes
+Central Thailand,Nonthaburi,Esplanade Cineplex Ngamwongwan-Khaerai & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,22.00 m,11.00 m,Yes
+Central Thailand,Samutprakarn,IMAX Mega Cineplex at Mega Bangna,1.90:1,IMAX Laser XT,1.90:1,No,19.60 m,10.20 m,Yes
+Central Thailand,Bangkok,"IMAX, Major Cineplex Ratchayothin",1.43:1,IMAX Cola,1.90:1,No,24.00 m,17.00 m,Yes
+Central Thailand,Bangkok,"Krungsri IMAX, Paragon Cineplex",1.43:1,IMAX Cola,1.90:1,No,27.30 m,19.90 m,Yes

--- a/docs/assets/csv/metric/asia/unitedarabemirates.csv
+++ b/docs/assets/csv/metric/asia/unitedarabemirates.csv
@@ -1,3 +1,3 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Abu Dhabi,Abu Dhabi,VOX Al Maryah & IMAX,1.90:1,IMAX Cola,1.90:1,No,0 m,0 m,Yes
-Dubai,Dubai,VOX Cinemas & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,23.90m,12.70m,Yes
+Dubai,Dubai,VOX Cinemas & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,23.90 m,12.70 m,Yes

--- a/docs/assets/csv/metric/asia/vietnam.csv
+++ b/docs/assets/csv/metric/asia/vietnam.csv
@@ -1,4 +1,4 @@
 Province,City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
-Ho Chi Minh City,Ho Chi Minh City,CGV Sư Vạn Hạnh & IMAX,1:90:1,IMAX Laser XT,1.90:1,No,21.34m,11.74m,Yes
-Ho Chi Minh City,Ho Chi Minh City,CGV AEON Bình Tân & IMAX,1:90:1,IMAX Laser XT,1.90:1,No,20.65m,11.30m,Yes
+Ho Chi Minh City,Ho Chi Minh City,CGV Sư Vạn Hạnh & IMAX,1:90:1,IMAX Laser XT,1.90:1,No,21.34 m,11.74 m,Yes
+Ho Chi Minh City,Ho Chi Minh City,CGV AEON Bình Tân & IMAX,1:90:1,IMAX Laser XT,1.90:1,No,20.65 m,11.30 m,Yes
 Ho Chi Minh City,Thu Duc,Galaxy Sala & IMAX,1:90:1,IMAX Laser XT,1:90:1,No,0 m,0 m,Yes


### PR DESCRIPTION
A lack of space between a number and the letter "m" will cause conversion issues in the Python script.
Using VSCode find and replace, the following regex will find it: `(\d+\.?\d*)m`
Then the following regex applies the fix: `$1 m`

This contains the corrections needed across all files.