### PR TITLE
Add Syracuse IMAX

### DIFF
--- a/data/americas/unitedstates.csv
+++ b/data/americas/unitedstates.csv
@@ -132,6 +132,7 @@ NY,New York,AMC Kips Bay 15 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.40 m,18.30 m,Yes
 NY,New York,AMC Lincoln Square 13 & IMAX,1.43:1,IMAX GT Laser,1.43:1,IMAX GT3D 15/70 mm,23.04 m,30.78 m,Yes
 NY,Staten Island,AMC Staten Island 11 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.40 m,16.80 m,Yes
 NY,Stony Brook,AMC Stony Brook 17 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.50 m,15.90 m,Yes
+NY,Syracuse,Regal Destiny USA & IMAX,1.90:1,IMAX CoLa,1.9.0,No,11.6 m,21.3 m,Yes
 OH,Cincinnati,Robert D. Lindner Family OMNIMAX® Theater,Dome 1.43:1,IMAX Laser for Dome,Dome 1.43:1,No,0 m,22.00 m,No
 OH,Columbus,Lennox Town Center & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.20 m,17.70 m,Yes
 OK,Moore,Regal Warren Moore & IMAX,1.43:1,IMAX CoLa,1.90:1,No,18.30 m,24.40 m,Yes


### PR DESCRIPTION
Syracuse recently re-opened from renovations and now has a new CoLa Projector.

Dimensions were sourced from lfexaminer