### PR TITLE
Add Regal UA Colorado Center & IMAX (Denver, CO)

### DIFF
--- a/data/americas/unitedstates.csv
+++ b/data/americas/unitedstates.csv
@@ -48,6 +48,7 @@ CA,Yorba Linda,Regal Yorba Linda & IMAX,1.90:1,IMAX CoLa,1.90:1,No,0 m,0 m,Yes
 CO,Broomfield,AMC Flatiron Crossing 14 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,0 m,0 m,Yes
 CO,Denver,AMC Orchard 12 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,10.00 m,15.60 m,Yes
 CO,Denver,AMC Westminster Promenade 24 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,10.60 m,15.90 m,Yes
+CO,Denver,Regal UA Colorado Center & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,0 m,0 m,Yes
 CO,Highlands Ranch,AMC Highlands Ranch 24 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,10.60 m,17.50 m,Yes
 CO,Loveland,Metrolux 12 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,0 m,0 m,Yes
 CT,Milford,Cinemark Connecticut Post 14 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,10.10 m,18.20 m,Yes


### PR DESCRIPTION
## Summary

Adds the missing **Regal UA Colorado Center & IMAX** theatre in Denver, Colorado to the US dataset.

## Theatre Details

| Field | Value |
|-------|-------|
| State | CO |
| City | Denver |
| Location | Regal UA Colorado Center & IMAX |
| Screen AR | 1.43:1 |
| Digital Projector | IMAX GT Laser |
| Max Digital AR | 1.43:1 |
| Film Projector | No |
| Height | 0 m (unknown) |
| Width | 0 m (unknown) |
| Commercial Films | Yes |

## Notes

- **Screen dimensions**: Marked as unknown (0 m). I was unable to find verified measurements from any authoritative source. Contributions welcome if anyone has exact figures.
- **Film projector**: Marked as `No`. While 70mm projectors may have been brought in for special screenings in the past, there does not appear to be a permanent 15/70mm installation at this location.
- Data validated with `python scripts/validate_data.py` — all checks pass (177 rows, 0 errors, 0 warnings).