### PR TITLE
Update unitedstates.csv

### DIFF
--- a/data/americas/unitedstates.csv
+++ b/data/americas/unitedstates.csv
@@ -130,10 +130,12 @@ NY,New York,AMC 34th Street 14 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.20 m,16.50 m,
 NY,New York,AMC Empire 25 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.50 m,17.70 m,Yes
 NY,New York,AMC Kips Bay 15 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.40 m,18.30 m,Yes
 NY,New York,AMC Lincoln Square 13 & IMAX,1.43:1,IMAX GT Laser,1.43:1,IMAX GT3D 15/70 mm,23.04 m,30.78 m,Yes
+NY,Port Chester,AMC Port Chester 14 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.2 m,17.1 m,Yes
 NY,Rochester,Cinemark Tinseltown Rochester and IMAX,1.90:1,IMAX CoLa,1.43:1,IMAX SR 15/70 mm,16.1 m,21.3 m,Yes
 NY,Staten Island,AMC Staten Island 11 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.40 m,16.80 m,Yes
 NY,Stony Brook,AMC Stony Brook 17 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.50 m,15.90 m,Yes
 NY,Syracuse,Regal Destiny USA & IMAX,1.90:1,IMAX CoLa,1.90,No,11.6 m,21.3 m,Yes
+NY,White Plains,Apple Cinemas White Plains City Center & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.4 m,18.1 m,Yes
 OH,Cincinnati,Robert D. Lindner Family OMNIMAX® Theater,Dome 1.43:1,IMAX Laser for Dome,Dome 1.43:1,No,0 m,22.00 m,No
 OH,Columbus,Lennox Town Center & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.20 m,17.70 m,Yes
 OK,Moore,Regal Warren Moore & IMAX,1.43:1,IMAX CoLa,1.90:1,No,18.30 m,24.40 m,Yes
@@ -164,6 +166,8 @@ TX,Houston,Showbiz Cinemas Liberty Lakes & IMAX,1.90:1,IMAX CoLa,1.90:1,No,0 m,0
 TX,San Antonio,AMC Rivercenter 11 & IMAX (Auditorium 11),1.43:1,IMAX Digital,1.90:1,No,16.10 m,21.30 m,Yes
 TX,Shenandoah,AMC Metropark 10 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,10.00 m,16.00 m,Yes
 TX,Waxahachie,EVO Entertainment Waxahachie & IMAX,1.90:1,IMAX CoLa,1.90:1,No,0 m,0 m,Yes
+UT,Salt Lake City,Clark Planetarium (Northrop Grumman IMAX Theatre),1.43:1,IMAX Digital,1.90:1,No,16.8 m,21.3 m,Limited
+UT,Sandy,Megaplex Sandy at Jordan Commons & IMAX,1.43:1,IMAX Digital,1.90:1,No,17.2 m,24.6 m,Yes
 VA,Alexandria,AMC Hoffman Center 22 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.5 m,15.5 m,Yes
 VA,Ashburn,Regal Fox & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.50 m,16.80 m,Yes
 VA,Chantilly,"Airbus IMAX, Steven F. Udvar-Hazy Center",1.43:1,IMAX GT Laser,1.43:1,No,19.00 m,26.10 m,Yes


### PR DESCRIPTION
Adds 4 missing IMAX theatres to `data/americas/unitedstates.csv`:

### New Entries

**New York**
- **AMC Port Chester 14** – Port Chester, NY | IMAX CoLa | 1.90:1 | 9.2 × 17.1 m
- **Apple Cinemas White Plains City Center & IMAX** – White Plains, NY | IMAX CoLa | 1.90:1 | 8.4 × 18.1 m

**Utah** *(new state block)*
- **Clark Planetarium (Northrop Grumman IMAX Theatre)** – Salt Lake City, UT | IMAX Digital | 1.43:1 | 16.8 × 21.3 m
- **Megaplex Sandy at Jordan Commons & IMAX** – Sandy, UT | IMAX Digital | 1.43:1 | 17.2 × 24.6 m