### PR TITLE
Update IMAX type for Cinemark Tinseltown Rochester

### DIFF
--- a/data/americas/unitedstates.csv
+++ b/data/americas/unitedstates.csv
@@ -131,7 +131,7 @@ NY,New York,AMC Empire 25 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.50 m,17.70 m,Yes
 NY,New York,AMC Kips Bay 15 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.40 m,18.30 m,Yes
 NY,New York,AMC Lincoln Square 13 & IMAX,1.43:1,IMAX GT Laser,1.43:1,IMAX GT3D 15/70 mm,23.04 m,30.78 m,Yes
 NY,Port Chester,AMC Port Chester 14 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.2 m,17.1 m,Yes
-NY,Rochester,Cinemark Tinseltown Rochester and IMAX,1.90:1,IMAX CoLa,1.43:1,IMAX SR 15/70 mm,16.1 m,21.3 m,Yes
+NY,Rochester,Cinemark Tinseltown Rochester and IMAX,1.90:1,IMAX Digital,1.43:1,IMAX SR 15/70 mm,16.1 m,21.3 m,Yes
 NY,Staten Island,AMC Staten Island 11 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,9.40 m,16.80 m,Yes
 NY,Stony Brook,AMC Stony Brook 17 & IMAX,1.90:1,IMAX CoLa,1.90:1,No,8.50 m,15.90 m,Yes
 NY,Syracuse,Regal Destiny USA & IMAX,1.90:1,IMAX CoLa,1.90,No,11.6 m,21.3 m,Yes


### PR DESCRIPTION
The digital system is the legacy IDS, also known as "Xenon". There is no Laser upgrade at this time.