### PR TITLE
Add analog projector info for Brussels IMAX screen

### DIFF
--- a/data/europe/belgium.csv
+++ b/data/europe/belgium.csv
@@ -1,5 +1,5 @@
 City,Location Name,Screen Aspect Ratio (AR),Digital Projector,Maximum AR for digital projection,Film Projector,Height,Width,Commercial films shown?
 Antwerp,Kinepolis Mega NV Antwerpen & IMAX,1.90:1,IMAX CoLa,1.90:1,No,11.0 m,20.0 m,Yes
-Brussels,Kinepolis Brussels & IMAX,1.43:1,IMAX GT Laser,1.43:1,No,19.3 m,27.6 m,Yes
+Brussels,Kinepolis Brussels & IMAX,1.43:1,IMAX GT Laser,1.43:1,IMAX GT 15/70mm,19.3 m,27.6 m,Yes
 Charleroi,Pathé Charleroi & IMAX,1.90:1,IMAX GT Laser,1.90:1,No,16.0 m,22.0 m,Yes
 Liège,Kinepolis Liege & IMAX,1.90:1,IMAX Laser XT,1.90:1,No,8.0 m,20.0 m,Yes


### PR DESCRIPTION
the imax in brussels added a 15/70 film projector ahead of the release of the odyssey. this is confirmed by the instagram posts by kinepolis from the projector en projection booth. source: https://www.instagram.com/p/DZe9XD7Dnmv/